### PR TITLE
Use context-aware services for context aware configuration export configuration to allow multi-tenancy

### DIFF
--- a/src/main/java/io/wcm/siteapi/processor/caconfig/ContextAwareConfigurationExport.java
+++ b/src/main/java/io/wcm/siteapi/processor/caconfig/ContextAwareConfigurationExport.java
@@ -1,0 +1,45 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2022 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.siteapi.processor.caconfig;
+
+import java.util.Collection;
+
+import org.jetbrains.annotations.NotNull;
+import org.osgi.annotation.versioning.ConsumerType;
+
+import io.wcm.sling.commons.caservice.ContextAwareService;
+
+/**
+ * Configures context-aware configuration names/classes to be exposed via Site API.
+ * <p>
+ * This can either be implemented as OSGI service, or configured via OSGI configuration
+ * by using {@link io.wcm.siteapi.processor.caconfig.impl.ContextAwareConfigurationExportImpl}.
+ * </p>
+ */
+@ConsumerType
+public interface ContextAwareConfigurationExport extends ContextAwareService {
+
+  /**
+   * @return List context-aware configuration names/classes.
+   */
+  @NotNull
+  Collection<String> getNames();
+
+}

--- a/src/main/java/io/wcm/siteapi/processor/caconfig/impl/ContextAwareConfigurationExportImpl.java
+++ b/src/main/java/io/wcm/siteapi/processor/caconfig/impl/ContextAwareConfigurationExportImpl.java
@@ -17,26 +17,29 @@
  * limitations under the License.
  * #L%
  */
-package io.wcm.siteapi.processor.impl.caconfig;
+package io.wcm.siteapi.processor.caconfig.impl;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
+import org.jetbrains.annotations.NotNull;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.Designate;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
+import io.wcm.siteapi.processor.caconfig.ContextAwareConfigurationExport;
+
 /**
  * Configures a list of context-aware configuration names/classes to be exposed via Site API.
  */
-@Designate(ocd = ContextAwareConfigurationExport.Config.class, factory = true)
+@Designate(ocd = ContextAwareConfigurationExportImpl.Config.class, factory = true)
 @Component(service = ContextAwareConfigurationExport.class, property = {
     "webconsole.configurationFactory.nameHint={names}"
 })
-public final class ContextAwareConfigurationExport {
+public final class ContextAwareConfigurationExportImpl implements ContextAwareConfigurationExport {
 
   @ObjectClassDefinition(
       name = "wcm.io Site API Context-Aware Configuration Export",
@@ -60,7 +63,8 @@ public final class ContextAwareConfigurationExport {
   /**
    * @return List context-aware configuration names/classes.
    */
-  public Collection<String> getNames() {
+  @Override
+  public @NotNull Collection<String> getNames() {
     return Collections.unmodifiableCollection(names);
   }
 

--- a/src/site/markdown/usage.md
+++ b/src/site/markdown/usage.md
@@ -18,7 +18,7 @@ You can enable the built-in processors by providing an OSGi configuration:
 For the `config` processor you can configure which Context-Aware configuration names should be exported:
 
 ```
-  io.wcm.siteapi.processor.impl.caconfig.ContextAwareConfigurationExport-XXX
+  io.wcm.siteapi.processor.impl.caconfig.ContextAwareConfigurationExportImpl-XXX
     names=["x.y.z.MyConfig1", "x.y.z.MyConfig2"]
 ```
 

--- a/src/test/java/io/wcm/siteapi/processor/impl/caconfig/ContextAwareConfigurationProcessorTest.java
+++ b/src/test/java/io/wcm/siteapi/processor/impl/caconfig/ContextAwareConfigurationProcessorTest.java
@@ -45,6 +45,7 @@ import org.mockito.Mock.Strictness;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.wcm.siteapi.processor.caconfig.ContextAwareConfigurationMapper;
+import io.wcm.siteapi.processor.caconfig.impl.ContextAwareConfigurationExportImpl;
 import io.wcm.siteapi.processor.textcontext.AppAemContext;
 import io.wcm.siteapi.processor.url.UrlBuilder;
 import io.wcm.testing.mock.aem.junit5.AemContext;
@@ -94,7 +95,7 @@ class ContextAwareConfigurationProcessorTest {
 
   @Test
   void testNonExistingConfig() {
-    context.registerInjectActivateService(ContextAwareConfigurationExport.class,
+    context.registerInjectActivateService(ContextAwareConfigurationExportImpl.class,
         "names", new String[] {
             "non-existing-config-1",
             "non-existing-config-2",
@@ -107,7 +108,7 @@ class ContextAwareConfigurationProcessorTest {
 
   @Test
   void testAllConfig() {
-    context.registerInjectActivateService(ContextAwareConfigurationExport.class,
+    context.registerInjectActivateService(ContextAwareConfigurationExportImpl.class,
         "names", new String[] {
             CONFIG_1_NAME,
             CONFIG_COLLECTION_2_NAME,
@@ -117,7 +118,7 @@ class ContextAwareConfigurationProcessorTest {
 
   @Test
   void testAllConfig_NoShortening() {
-    context.registerInjectActivateService(ContextAwareConfigurationExport.class,
+    context.registerInjectActivateService(ContextAwareConfigurationExportImpl.class,
         "names", new String[] {
             CONFIG_1_NAME,
             CONFIG_COLLECTION_2_NAME,
@@ -134,7 +135,7 @@ class ContextAwareConfigurationProcessorTest {
 
     when(urlBuilder.build(any(), eq(PROCESSOR_CONFIG), eq("Config3"), any())).thenReturn("/dummy.json");
 
-    context.registerInjectActivateService(ContextAwareConfigurationExport.class,
+    context.registerInjectActivateService(ContextAwareConfigurationExportImpl.class,
         "names", new String[] {
             CONFIG_1_NAME,
             CONFIG_COLLECTION_2_NAME,
@@ -146,7 +147,7 @@ class ContextAwareConfigurationProcessorTest {
 
   @Test
   void testSingleConfig() {
-    context.registerInjectActivateService(ContextAwareConfigurationExport.class,
+    context.registerInjectActivateService(ContextAwareConfigurationExportImpl.class,
         "names", new String[] {
             CONFIG_1_NAME,
             CONFIG_COLLECTION_2_NAME,
@@ -156,7 +157,7 @@ class ContextAwareConfigurationProcessorTest {
 
   @Test
   void testSingleConfigCollection() {
-    context.registerInjectActivateService(ContextAwareConfigurationExport.class,
+    context.registerInjectActivateService(ContextAwareConfigurationExportImpl.class,
         "names", new String[] {
             CONFIG_1_NAME,
             CONFIG_COLLECTION_2_NAME,


### PR DESCRIPTION
Breaking Change: Class name change for OSGI configuration:
`io.wcm.siteapi.processor.impl.caconfig.ContextAwareConfigurationExport-XXX` ->   `io.wcm.siteapi.processor.caconfig.impl.ContextAwareConfigurationExportImpl-XXX`